### PR TITLE
Update credit-card-form.html

### DIFF
--- a/view/frontend/web/template/payment/credit-card-form.html
+++ b/view/frontend/web/template/payment/credit-card-form.html
@@ -70,7 +70,7 @@
                                 keydown: creditCardMask.bind($data, document.getElementById('pagseguro_credit_card_number'))
                             }
                     "/>
-                    <div style="display: none;" class="mage-error display-none validation-advice pagseguro_credit_card_number-error-message" data-bind="attr: {generated: true}">Insira um número de cartão válido</div>
+                    <div style="display: none;" class="display-none validation-advice pagseguro_credit_card_number-error-message" data-bind="attr: {generated: true}">Insira um número de cartão válido</div>
                 </div>
             </div>
             
@@ -97,7 +97,7 @@
                                 keydown: notNumberMask.bind($data, document.getElementById('creditCardHolder'))
                             }
                     "/>
-                    <div style="display: none;" class="mage-error display-none validation-advice creditCardHolder-error-message" data-bind="attr: {generated: true}">Insira um nome válido</div>
+                    <div style="display: none;" class="display-none validation-advice creditCardHolder-error-message" data-bind="attr: {generated: true}">Insira um nome válido</div>
                 </div>
             </div>
             
@@ -145,10 +145,10 @@
                     </div>
                     <div class="fields group group-2">
                         <div class="field no-label month">
-                            <div style="display: none;" class="mage-error display-none validation-advice creditCardExpirationMonth-error-message" data-bind="attr: {generated: true}">Escolha um mês</div>
+                            <div style="display: none;" class="display-none validation-advice creditCardExpirationMonth-error-message" data-bind="attr: {generated: true}">Escolha um mês</div>
                         </div>
                         <div class="field no-label year">
-                            <div style="display: none;" class="mage-error display-none validation-advice creditCardExpirationYear-error-message" data-bind="attr: {generated: true}">Escolha um ano</div>
+                            <div style="display: none;" class="display-none validation-advice creditCardExpirationYear-error-message" data-bind="attr: {generated: true}">Escolha um ano</div>
                         </div>
                     </div>
                 </div>
@@ -178,7 +178,7 @@
                                 keydown: creditCardCodeMask.bind($data,document.getElementById('creditCardCode'))
                             }
                     "/>
-                    <div style="display: none;" class="mage-error display-none validation-advice creditCardCode-error-message" data-bind="attr: {generated: true}">Insira um código válido</div>
+                    <div style="display: none;" class="display-none validation-advice creditCardCode-error-message" data-bind="attr: {generated: true}">Insira um código válido</div>
                 </div>
             </div>
 
@@ -207,7 +207,7 @@
                                 keydown: mascaraMutuario(document.getElementById('creditCardDocument'), cpfCnpj)
                             }
                     "/>
-                    <div style="display: none;" class="mage-error display-none validation-advice creditCardDocument-error-message" data-bind="attr: {generated: true}">Insira um CPF ou CNPJ válido</div>
+                    <div style="display: none;" class="display-none validation-advice creditCardDocument-error-message" data-bind="attr: {generated: true}">Insira um CPF ou CNPJ válido</div>
                 </div>
             </div>
 
@@ -237,7 +237,7 @@
                                 keydown: MascaraData.bind($data,document.getElementById('creditCardHolderBirthdate'))
                             }
                     "/>
-                    <div style="display: none;" class="mage-error display-none validation-advice creditCardHolderBirthdate-error-message" data-bind="attr: {generated: true}">Insira uma data de nascimento válida</div>
+                    <div style="display: none;" class="display-none validation-advice creditCardHolderBirthdate-error-message" data-bind="attr: {generated: true}">Insira uma data de nascimento válida</div>
                 </div>
             </div>
             
@@ -258,7 +258,7 @@
                     ">
                         <option value="null" disabled selected>Escolha o N° de parcelas</option>
                     </select>
-                    <div style="display: none;" class="mage-error display-none validation-advice card_installment_option-error-message" data-bind="attr: {generated: true}">Escolha uma opção de parcelamento</div>
+                    <div style="display: none;" class="display-none validation-advice card_installment_option-error-message" data-bind="attr: {generated: true}">Escolha uma opção de parcelamento</div>
                 </div>
             </div>
             
@@ -277,7 +277,7 @@
             
             <div class="credit-card-error-ps pagseguro-label-spacing pagseguro-cc-group-div" style="font-weight: bold; text-align: center;">
                 <div style="display: none; font-weight: bold; text-align: center;"
-                    class="mage-error display-none validation-advice creditCardToken-error-message"
+                    class="display-none validation-advice creditCardToken-error-message"
                     data-bind="attr: {generated: true}"
                 >
                     Dados do cartão inválidos. Verifique o número, a validade e o código de segurança do cartão inseridos e tente novamente.


### PR DESCRIPTION
mage-error não está chamando na UI do Magento e valida em JS customizado, conflitando com estilos do styles-m.less e disparando mesmo que o formulário seja válido. Remover a classe resolve o problema